### PR TITLE
Add dual license boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .DS_Store
+.npmrc

--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -1,0 +1,19 @@
+# Commercial License Agreement
+
+## Grant of License
+A non-exclusive, non-transferable license to use the Software in proprietary products.
+
+## Restrictions
+Licensee may not redistribute, sublicense, or otherwise make the Software available outside their organization without express permission.
+
+## Fees and Royalties
+Licensee agrees to pay licensing fees as per a separate agreement.
+
+## Warranty Disclaimer
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
+
+## Limitation of Liability
+IN NO EVENT SHALL THE LICENSOR BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY.
+
+## Contact
+For commercial licensing inquiries, contact sales@yourcompany.com.

--- a/LICENSE-OSS.md
+++ b/LICENSE-OSS.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Dave Weinberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -224,3 +224,8 @@ MIT License.
 - `ai-infrastructure`
 - `gently-ventures`
 - `llm-pipeline`
+
+## License
+
+Bootloader is available under the MIT License for community use.  
+For a commercial license (no copyleft), see [LICENSE-COMMERCIAL.md](LICENSE-COMMERCIAL.md) or contact [sales@yourcompany.com](mailto:sales@yourcompany.com).

--- a/packages/core/__tests__/smoke.test.js
+++ b/packages/core/__tests__/smoke.test.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Commercial
+// Copyright (c) 2025 Dave Weinberg
 const core = require('@gentlyventures/bootloader-core');
 test('core module loads', () => {
   expect(typeof core.registerAdapter).toBe('function');

--- a/packages/core/figma-agent-template/code.js
+++ b/packages/core/figma-agent-template/code.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Commercial
+// Copyright (c) 2025 Dave Weinberg
 // Placeholder entry point for Figma plugin.
 // Codex will inject nodes or update components via the Figma Write API.
 

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Commercial
+// Copyright (c) 2025 Dave Weinberg
 const adapters = {};
 function registerAdapter(name, setup) {
   adapters[name] = setup;

--- a/packages/core/src/ops/bootloader/run-all.ts
+++ b/packages/core/src/ops/bootloader/run-all.ts
@@ -1,1 +1,3 @@
+// SPDX-License-Identifier: MIT OR Commercial
+// Copyright (c) 2025 Dave Weinberg
 console.log("run-all.ts is not implemented yet. Begin execution from TODO.md manually.");

--- a/packages/portia-adapter/__tests__/smoke.test.js
+++ b/packages/portia-adapter/__tests__/smoke.test.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Commercial
+// Copyright (c) 2025 Dave Weinberg
 const adapter = require('@gentlyventures/bootloader-portia-adapter');
 test('portia adapter loads', () => {
   expect(typeof adapter.registerAdapter).toBe('function');

--- a/packages/portia-adapter/src/index.js
+++ b/packages/portia-adapter/src/index.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Commercial
+// Copyright (c) 2025 Dave Weinberg
 const { registerAdapter } = require('@gentlyventures/bootloader-core');
 let portia;
 try {

--- a/packages/portia-adapter/templates/config.py
+++ b/packages/portia-adapter/templates/config.py
@@ -1,1 +1,3 @@
+// SPDX-License-Identifier: MIT OR Commercial
+// Copyright (c) 2025 Dave Weinberg
 # Portia config for {{projectName}}

--- a/packages/portia-adapter/templates/plan.py
+++ b/packages/portia-adapter/templates/plan.py
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Commercial
+// Copyright (c) 2025 Dave Weinberg
 from portia import Plan
 
 class {{projectName}}Plan(Plan):


### PR DESCRIPTION
## Summary
- add MIT and Commercial license files
- document license options in README
- prepend SPDX headers to source files
- ignore accidental `.npmrc` files

## Testing
- `npm run test:core` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584dfda3748328a235757fda3e8343