### PR TITLE
Migrate Conductor module into workspace package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -794,6 +794,10 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@gentlyventures/bootloader-conductor": {
+      "resolved": "packages/conductor",
+      "link": true
+    },
     "node_modules/@gentlyventures/bootloader-core": {
       "resolved": "packages/core",
       "link": true
@@ -8676,6 +8680,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "packages/conductor": {
+      "name": "@gentlyventures/bootloader-conductor",
+      "version": "0.1.0",
+      "license": "MIT"
     },
     "packages/core": {
       "name": "@gentlyventures/bootloader-core",

--- a/packages/conductor/index.js
+++ b/packages/conductor/index.js
@@ -1,0 +1,7 @@
+class Conductor {
+  run(script) {
+    console.log(`Running conductor script: ${script}`);
+  }
+}
+
+module.exports = Conductor;

--- a/packages/conductor/package.json
+++ b/packages/conductor/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@gentlyventures/bootloader-conductor",
+  "version": "0.1.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "test": "jest"
+  }
+}

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -2,6 +2,7 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import core from '@gentlyventures/bootloader-core';
+import Conductor from '@gentlyventures/bootloader-conductor';
 
 const argv = yargs(hideBin(process.argv))
   .scriptName('boot')
@@ -9,6 +10,12 @@ const argv = yargs(hideBin(process.argv))
     yargs.positional('name', { type: 'string', describe: 'Project name' });
   }, async ({ name }) => {
     await core.bootstrapProject(name);
+  })
+  .command('conductor <script>', 'Run Conductor script', yargs => {
+    yargs.positional('script', { type: 'string', describe: 'Script to run' });
+  }, async ({ script }) => {
+    const conductor = new Conductor();
+    conductor.run(script);
   })
   .help()
   .argv;


### PR DESCRIPTION
## Summary
- add `packages/conductor` workspace package
- expose basic Conductor class
- update CLI to use `@gentlyventures/bootloader-conductor`
- refresh package-lock with new workspace package

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685851929cbc8328a34c7c4c824ae304