### PR TITLE
Rename Conductor to Init-Phase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -794,8 +794,8 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@gentlyventures/bootloader-conductor": {
-      "resolved": "packages/conductor",
+    "node_modules/@gentlyventures/bootloader-init-phase": {
+      "resolved": "packages/init-phase",
       "link": true
     },
     "node_modules/@gentlyventures/bootloader-core": {
@@ -8681,8 +8681,8 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/conductor": {
-      "name": "@gentlyventures/bootloader-conductor",
+    "packages/init-phase": {
+      "name": "@gentlyventures/bootloader-init-phase",
       "version": "0.1.0",
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "typescript": "^5.8.3"
   },
   "workspaces": [
-    "packages/*"
+    "packages/core",
+    "packages/langgraph-adapter",
+    "packages/portia-adapter",
+    "packages/init-phase"
   ],
   "bin": {
     "boot": "tools/cli.js"

--- a/packages/conductor/index.js
+++ b/packages/conductor/index.js
@@ -1,7 +1,0 @@
-class Conductor {
-  run(script) {
-    console.log(`Running conductor script: ${script}`);
-  }
-}
-
-module.exports = Conductor;

--- a/packages/init-phase/index.js
+++ b/packages/init-phase/index.js
@@ -1,0 +1,7 @@
+class InitPhase {
+  run(script) {
+    console.log(`Running init script: ${script}`);
+  }
+}
+
+module.exports = InitPhase;

--- a/packages/init-phase/package.json
+++ b/packages/init-phase/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gentlyventures/bootloader-conductor",
+  "name": "@gentlyventures/bootloader-init-phase",
   "version": "0.1.0",
   "main": "index.js",
   "license": "MIT",

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -2,7 +2,7 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import core from '@gentlyventures/bootloader-core';
-import Conductor from '@gentlyventures/bootloader-conductor';
+import InitPhase from '@gentlyventures/bootloader-init-phase';
 
 const argv = yargs(hideBin(process.argv))
   .scriptName('boot')
@@ -11,11 +11,11 @@ const argv = yargs(hideBin(process.argv))
   }, async ({ name }) => {
     await core.bootstrapProject(name);
   })
-  .command('conductor <script>', 'Run Conductor script', yargs => {
-    yargs.positional('script', { type: 'string', describe: 'Script to run' });
-  }, async ({ script }) => {
-    const conductor = new Conductor();
-    conductor.run(script);
+  .command('init <projectName>', 'Initialize a new project pre-flight', yargs => {
+    yargs.positional('projectName', { type: 'string', describe: 'Project name' });
+  }, async ({ projectName }) => {
+    const initPhase = new InitPhase();
+    initPhase.run(projectName);
   })
   .help()
   .argv;


### PR DESCRIPTION
## Summary
- rename `packages/conductor` to `packages/init-phase`
- update workspace paths
- rename module and adjust CLI command

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595d08f17083288fc9ce7b36e62b5d