### PR TITLE
Add smoke test for init-phase package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6629,7 +6629,13 @@
     "packages/init-phase": {
       "name": "@gentlyventures/bootloader-init-phase",
       "version": "0.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.4.0",
+        "typescript": "^5.8.3"
+      }
     },
     "packages/langgraph-adapter": {
       "name": "@gentlyventures/bootloader-langgraph-adapter",

--- a/packages/init-phase/__tests__/smoke.test.js
+++ b/packages/init-phase/__tests__/smoke.test.js
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT OR Commercial
+// Copyright (c) 2025 Dave Weinberg
+const InitPhase = require('@gentlyventures/bootloader-init-phase');
+
+describe('InitPhase package', () => {
+  test('exports a run method', () => {
+    expect(typeof new InitPhase('test').run).toBe('function');
+  });
+});

--- a/packages/init-phase/package.json
+++ b/packages/init-phase/package.json
@@ -5,5 +5,11 @@
   "license": "MIT",
   "scripts": {
     "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.0",
+    "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest smoke test for init-phase package
- add Jest devDependencies for init-phase

## Testing
- `npx jest --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68596b30b5c883289d93f8f92955c1b2