### PR TITLE
Scaffold langgraph adapter package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6639,7 +6639,13 @@
     },
     "packages/langgraph-adapter": {
       "name": "@gentlyventures/bootloader-langgraph-adapter",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "devDependencies": {
+        "@types/jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "ts-jest": "^29.0.0",
+        "typescript": "^5.0.0"
+      }
     },
     "packages/portia-adapter": {
       "name": "@gentlyventures/bootloader-portia-adapter",

--- a/packages/langgraph-adapter/README.md
+++ b/packages/langgraph-adapter/README.md
@@ -1,0 +1,9 @@
+# Bootloader LangGraph Adapter
+
+This adapter integrates Bootloader with a LangGraph pipeline.
+
+## Quickstart
+```bash
+boot new my-project --langgraph
+cd my-project
+```

--- a/packages/langgraph-adapter/__tests__/smoke.test.js
+++ b/packages/langgraph-adapter/__tests__/smoke.test.js
@@ -1,0 +1,4 @@
+const adapter = require('@gentlyventures/bootloader-langgraph-adapter');
+test('langgraph adapter loads', () => {
+  expect(typeof adapter).toBe('object');
+});

--- a/packages/langgraph-adapter/package.json
+++ b/packages/langgraph-adapter/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@gentlyventures/bootloader-langgraph-adapter",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  "scripts": {
+    "build": "echo 'No build step yet'",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "typescript": "^5.0.0"
+  }
 }
-

--- a/packages/langgraph-adapter/tsconfig.json
+++ b/packages/langgraph-adapter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "strict": true
+  }
+}


### PR DESCRIPTION
## Summary
- create README quickstart for LangGraph adapter
- scaffold TypeScript config and base tsconfig
- add Jest smoke test
- update package.json scripts and dev dependencies
- update lockfile with new packages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a70216348328a87654617040244f