### PR TITLE
Update docs and package README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Bootloader is a monorepo-based scaffolding engine that turns a single prompt int
 - [Getting Started with Codex](#getting-started-with-codex)
 - [Getting Started with Portia](#getting-started-with-portia)
 - [Usage](#usage)
+- [Core](packages/core/README.md)
+- [Init Phase](packages/init-phase/README.md)
+- [Portia Adapter](packages/portia-adapter/README.md)
+- [LangGraph Adapter](packages/langgraph-adapter/README.md)
+- [Tools](tools/README.md)
+- [Examples](examples/README.md)
 
 ## Pre-Setup
 
@@ -209,6 +215,11 @@ Codex must:
 Paste that into the bottom of any Codex prompt before execution.
 
 ---
+
+## Documentation
+
+- Architecture overview: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- Agent registry: [AGENTS.md](AGENTS.md)
 
 ## 🧑‍💻 Maintained by Gently Ventures
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,12 @@
 # Bootloader Architecture
 
-_TBD: Overview of the bootloader packages and how they interact._
+Bootloader is a modular scaffolding engine composed of:
 
+- **Core**: `packages/core` – the central agent factory providing scaffolding primitives.
+- **Init Phase**: `packages/init-phase` – pre-flight assessment and project initialization.
+- **Portia Adapter**: `packages/portia-adapter` – opinionated scaffolding for PortiaAI.
+- **LangGraph Adapter**: `packages/langgraph-adapter` – scaffolding for LangGraph pipelines.
+- **Tools**: `tools` – CLI entrypoints and utility scripts.
+- **Examples**: `examples/hello-bootloader` – a sample project demonstrating usage.
+
+Each module contains its own README and smoke tests. CI is configured via GitHub Actions in `.github/workflows/ci.yml`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+# Bootloader Examples
+
+Collection of sample projects demonstrating Bootloader usage.
+
+- [Hello Bootloader](hello-bootloader/README.md)
+
+See the [Bootloader README](../README.md) for setup instructions.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,11 @@
+# Bootloader Core
+
+The core package provides the agent factory and base scaffolding primitives for Bootloader.
+
+## Quickstart
+
+```bash
+npm install @gentlyventures/bootloader-core
+```
+
+See the [Bootloader README](../../README.md) for usage details.

--- a/packages/init-phase/README.md
+++ b/packages/init-phase/README.md
@@ -1,0 +1,11 @@
+# Bootloader Init Phase
+
+Handles pre-flight assessment and project initialization steps before scaffolding begins.
+
+## Quickstart
+
+```bash
+npm install @gentlyventures/bootloader-init-phase
+```
+
+See the [Bootloader README](../../README.md) for more information.

--- a/packages/langgraph-adapter/README.md
+++ b/packages/langgraph-adapter/README.md
@@ -7,3 +7,5 @@ This adapter integrates Bootloader with a LangGraph pipeline.
 boot new my-project --langgraph
 cd my-project
 ```
+
+See the [Bootloader README](../../README.md) for more details.

--- a/packages/portia-adapter/README.md
+++ b/packages/portia-adapter/README.md
@@ -9,3 +9,5 @@ This adapter lets Bootloader scaffold Portia plans and tools. Use
 boot --portia my-portia-project
 cd my-portia-project
 ```
+
+See the [Bootloader README](../../README.md) for more details.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,11 @@
+# Bootloader Tools
+
+This package contains CLI entrypoints and utility scripts used by Bootloader.
+
+## Quickstart
+
+```bash
+npx ts-node tools/bootstrap-module.ts my-module
+```
+
+See the [Bootloader README](../README.md) for full instructions.


### PR DESCRIPTION
## Summary
- document Bootloader architecture
- link packages in the main README
- add documentation links to README
- add READMEs for all packages and examples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859cf1476e48328974b0a4310339653