### PR TITLE
Update Jest config for integration tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,7 +2,10 @@ module.exports = {
   projects: [
     '<rootDir>/packages/core',
     '<rootDir>/packages/portia-adapter',
-    '<rootDir>/packages/init-phase'
+    '<rootDir>/packages/init-phase',
+    '<rootDir>/packages/langgraph-adapter',
+    '<rootDir>/tools',
+    '<rootDir>/tests/integration'
   ],
   testMatch: ['**/__tests__/**/*.test.[jt]s?(x)'],
   testEnvironment: 'node'


### PR DESCRIPTION
## Summary
- include `<rootDir>/tests/integration` in Jest `projects`

## Testing
- `npm run test:e2e` *(fails: Missing script `test:e2e`)*

------
https://chatgpt.com/codex/tasks/task_e_685a0db9af3483288c497bcb5214e5af