### PR TITLE
Fix: enable CommonJS in core package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@gentlyventures/bootloader-core",
   "version": "1.0.0",
   "description": "Modular scaffolding engine for Codex-based projects",
-  "type": "module",
+  "type": "commonjs",
   "devDependencies": {
     "@types/jest": "^29.0.0",
     "@types/node": "^24.0.3",


### PR DESCRIPTION
## Summary
- set the `type` field in `packages/core/package.json` to `commonjs`

## Testing
- `npx boot init my-test-app`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_685a16c2bf3c83288195d2104fc3e60d