### PR TITLE
Add explicit lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:tools": "cd tools && npm test",
     "test": "jest",
     "test:e2e": "jest --config jest.config.cjs",
+    "lint": "eslint -c .eslintrc.json \"**/*.{js,ts}\"",
     "build:cli": "pkg . --out-path dist/cli",
     "publish:cli": "npm publish --access public"
   },


### PR DESCRIPTION
## Summary
- add a lint script that explicitly points at `.eslintrc.json`

## Testing
- `npm run lint` *(fails: TypeError [ERR_IMPORT_ASSERTION_TYPE_MISSING])*

------
https://chatgpt.com/codex/tasks/task_e_685abac0a5848328a00690ec4ad50265